### PR TITLE
Fix twindb's MTA hostname

### DIFF
--- a/environments/production/data/mta.yaml
+++ b/environments/production/data/mta.yaml
@@ -2,7 +2,7 @@
 classes:
   - role::mta
 
-profile::postfix::myhostname: mail.twindb.com
+profile::postfix::myhostname: mail
 profile::postfix::mydomain: twindb.com
 profile::postfix::mydestination:
   - twindb.com


### PR DESCRIPTION
`profile::postfix::myhostname` should include hostname part only. i.e. "mail", not "mail.twindb.com". The domain part is added where necessary