### PR TITLE
Upgrade CD pipeline from jammy to noble

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -22,7 +22,7 @@ env:
 
 jobs:
     deploy:
-        runs-on: ubuntu-22.04
+        runs-on: ubuntu-24.04
         strategy:
             matrix:
                 codename: ["noble"]

--- a/support/install_deps.sh
+++ b/support/install_deps.sh
@@ -2,7 +2,7 @@
 
 set -eux
 
-CODENAME="jammy"
+CODENAME="noble"
 GPG_KEY_DIR=/etc/apt/cloud-init.gpg.d
 GPG_KEY_PUB="${GPG_KEY_DIR}/infrahouse.gpg"
 GPG_KEY_URL="https://release-${CODENAME}.infrahouse.com/DEB-GPG-KEY-release-${CODENAME}.infrahouse.com"


### PR DESCRIPTION
## Summary
- Upgrade GitHub Actions runner from `ubuntu-22.04` to `ubuntu-24.04`
- Change `install_deps.sh` codename from `jammy` to `noble`
- Fixes expired jammy APT signing key breaking the CD pipeline: https://github.com/infrahouse/infrahouse-puppet-data/actions/runs/26485221182/job/77991124185

## Test plan
- [ ] Verify the CD workflow runs successfully after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)